### PR TITLE
Refactor: Don't use callbacks for exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ logs/*
 docker/mysql/data
 docker/mysql/logs
 docker/nginx/logs
-dashboard.html
+dashboard*.html
 
 # Dependencies
 vendor/

--- a/.tooling/psalm/psalm-baseline.xml
+++ b/.tooling/psalm/psalm-baseline.xml
@@ -24,25 +24,12 @@
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$this->containerHosts[$indexOfFirstUnusedContainerHost]]]></code>
       <code><![CDATA[$this->containerHosts[$indexOfFirstUnusedContainerHost]]]></code>
-      <code><![CDATA[$this->containerHosts[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->containerHosts[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->containerHosts[$indexOfSelectedHost]]]></code>
       <code><![CDATA[$this->maxContainers[$indexOfFirstUnusedContainerHost]]]></code>
       <code><![CDATA[$this->maxContainers[$indexOfFirstUnusedContainerHost]]]></code>
-      <code><![CDATA[$this->maxContainers[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->maxContainers[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->maxContainers[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->maxContainers[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->maxContainers[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->privateKeys[$hostIndex]]]></code>
       <code><![CDATA[$this->privateKeys[$indexOfFirstUnusedContainerHost]]]></code>
       <code><![CDATA[$this->privateKeys[$indexOfFirstUnusedContainerHost]]]></code>
-      <code><![CDATA[$this->privateKeys[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->privateKeys[$indexOfSelectedHost]]]></code>
       <code><![CDATA[$this->tlsCertificates[$indexOfFirstUnusedContainerHost]]]></code>
       <code><![CDATA[$this->tlsCertificates[$indexOfFirstUnusedContainerHost]]]></code>
-      <code><![CDATA[$this->tlsCertificates[$indexOfSelectedHost]]]></code>
-      <code><![CDATA[$this->tlsCertificates[$indexOfSelectedHost]]]></code>
     </PossiblyUndefinedIntArrayOffset>
     <PossiblyUndefinedStringArrayOffset>
       <code><![CDATA[$_ENV['CONTAINER_HOSTS']]]></code>
@@ -53,7 +40,6 @@
       <code><![CDATA[$determinedContainerHost['cert']]]></code>
       <code><![CDATA[$determinedContainerHost['host']]]></code>
       <code><![CDATA[$determinedContainerHost['host']]]></code>
-      <code><![CDATA[$determinedContainerHost['privateKey']]]></code>
     </PossiblyUndefinedStringArrayOffset>
   </file>
 </files>

--- a/src/Commands/Statistics/DashboardUpdate.php
+++ b/src/Commands/Statistics/DashboardUpdate.php
@@ -11,8 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class DashboardUpdate extends Command
 {
-    private const DAYS_TO_SHOW = 1;
-
     private const DASHBOARD_TEMPLATE = /** @lang HTML */
         <<<TPL
 <!DOCTYPE html>
@@ -259,10 +257,10 @@ TPL;
      *
      * @throws \JsonException
      */
-    private function createContainersPerHostChart(): array
+    private function createContainersPerHostChart(int $daysToShow): array
     {
         $labels = $datasets = [];
-        $dataPoints = $this->serviceContainer->statistics->getContainerHostUsageForTimeframe(new \DateTime('-' . (string) self::DAYS_TO_SHOW . ' days'));
+        $dataPoints = $this->serviceContainer->statistics->getContainerHostUsageForTimeframe(new \DateTime('-' . (string) $daysToShow . ' days'));
         foreach ($dataPoints as $timeOfCapture => $hostAndCountPerPoint) {
             $labels[] = (new \DateTime($timeOfCapture))->format('H:i');
 
@@ -299,10 +297,10 @@ TPL;
      *
      * @throws \JsonException
      */
-    private function createTotalsChart(): array
+    private function createTotalsChart(int $daysToShow): array
     {
         $labels = $datasets = [];
-        $dataPoints = $this->serviceContainer->statistics->getTotalsForTimeframe(new \DateTime('-' . (string) self::DAYS_TO_SHOW . ' days'));
+        $dataPoints = $this->serviceContainer->statistics->getTotalsForTimeframe(new \DateTime('-' . (string) $daysToShow . ' days'));
         foreach ($dataPoints as $dataPoint) {
             $labels[] = (new \DateTime($dataPoint['timeOfCapture']))->format('H:i');
             foreach ($dataPoint as $valueName => $singleValue) {
@@ -353,59 +351,66 @@ TPL;
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        try {
-            [
-                $jsContainersPerHostLabels,
-                $jsContainersPerHostDatasets
-            ] = $this->createContainersPerHostChart();
-
-            [
-                $jsTotalLabels,
-                $jsTotalDatasets
-            ] = $this->createTotalsChart();
-
-            $htmlOutput = str_replace(
-                [
-                    '%containersPerHostLabels%',
-                    '%containersPerHostDatasets%',
-                    '%totalSessions%',
-                    '%totalContainers%',
-                    '%maxContainers%',
-                    '%totalLabels%',
-                    '%totalDatasets%',
-                    '%sessionsAlltime%',
-                    '%containersMaxConcurrent%',
-                    '%daysToShow%',
-                ],
+        foreach([1, 7, 30] as $daysToShow) {
+            try {
                 [
                     $jsContainersPerHostLabels,
-                    $jsContainersPerHostDatasets,
-                    $this->serviceContainer->pdo->query('SELECT COUNT(`id`) FROM `sessions`')->fetch()[0],
-                    $this->serviceContainer->dockerManager->countsPortsUsed(),
-                    $this->serviceContainer->dockerManager->countTotalMaxContainers(),
-                    $jsTotalLabels,
-                    $jsTotalDatasets,
-                    $this->serviceContainer->statistics->getTotalSessionsServed(),
-                    $this->serviceContainer->statistics->getMaxConcurrentContainersServed(),
-                    self::DAYS_TO_SHOW,
-                ],
-                self::DASHBOARD_TEMPLATE,
-            );
+                    $jsContainersPerHostDatasets
+                ] = $this->createContainersPerHostChart($daysToShow);
 
-            file_put_contents('dashboard.html', $htmlOutput);
-
-            return self::SUCCESS;
-        } catch (\Throwable $throwable) {
-            $this->serviceContainer->logger->warning(
-                sprintf('Throwable occurred in %s', self::class),
                 [
-                    'message' => $throwable->getMessage(),
-                    'trace' => $throwable->getTrace(),
-                ],
-            );
+                    $jsTotalLabels,
+                    $jsTotalDatasets
+                ] = $this->createTotalsChart($daysToShow);
 
-            return self::FAILURE;
+                $htmlOutput = str_replace(
+                    [
+                        '%containersPerHostLabels%',
+                        '%containersPerHostDatasets%',
+                        '%totalSessions%',
+                        '%totalContainers%',
+                        '%maxContainers%',
+                        '%totalLabels%',
+                        '%totalDatasets%',
+                        '%sessionsAlltime%',
+                        '%containersMaxConcurrent%',
+                        '%daysToShow%',
+                    ],
+                    [
+                        $jsContainersPerHostLabels,
+                        $jsContainersPerHostDatasets,
+                        $this->serviceContainer->pdo->query('SELECT COUNT(`id`) FROM `sessions`')->fetch()[0],
+                        $this->serviceContainer->dockerManager->countsPortsUsed(),
+                        $this->serviceContainer->dockerManager->countTotalMaxContainers(),
+                        $jsTotalLabels,
+                        $jsTotalDatasets,
+                        $this->serviceContainer->statistics->getTotalSessionsServed(),
+                        $this->serviceContainer->statistics->getMaxConcurrentContainersServed(),
+                        $daysToShow,
+                    ],
+                    self::DASHBOARD_TEMPLATE,
+                );
+
+                $filename = 'dashboard.html';
+                if ($daysToShow !== 1) {
+                    $filename = sprintf('dashboard.%dd.html', $daysToShow);
+                }
+
+                file_put_contents($filename, $htmlOutput);
+            } catch (\Throwable $throwable) {
+                $this->serviceContainer->logger->warning(
+                    sprintf('Throwable occurred in %s', self::class),
+                    [
+                        'message' => $throwable->getMessage(),
+                        'trace' => $throwable->getTrace(),
+                    ],
+                );
+
+                return self::FAILURE;
+            }
         }
+
+        return self::SUCCESS;
     }
 
     private function randomRgbCssColorCode(): string

--- a/src/Commands/Statistics/DashboardUpdate.php
+++ b/src/Commands/Statistics/DashboardUpdate.php
@@ -351,7 +351,7 @@ TPL;
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        foreach([1, 7, 30] as $daysToShow) {
+        foreach ([1, 7, 30] as $daysToShow) {
             try {
                 [
                     $jsContainersPerHostLabels,

--- a/src/DockerManager.php
+++ b/src/DockerManager.php
@@ -222,7 +222,7 @@ final class DockerManager
      */
     public function stopContainer(Session $session): void
     {
-        if (null === $session->wrpContainerId) {
+        if (null === $session->wrpContainerId || null === $session->containerHost) {
             throw new \LogicException(
                 sprintf(
                     'Session %d has no container attached! I would suggest calling startContainer() before, but since you wanted to stop it... lol...',
@@ -601,6 +601,9 @@ final class DockerManager
         return $return;
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     private function getIndexByHostname(string $hostname): int
     {
         $return = array_search($hostname, $this->containerHosts, true);
@@ -612,9 +615,18 @@ final class DockerManager
         return $return;
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     private function getSshConnnection(string $hostname): SSH2
     {
-        $callingMethod = debug_backtrace(!DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS,2)[1]['function'];
+        /**
+         * @psalm-suppress PossiblyUndefinedIntArrayOffset
+         */
+        $callingMethod = debug_backtrace(
+            (int) !DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS,
+            2
+        )[1]['function'];
 
         $hostIndex = $this->getIndexByHostname($hostname);
         [$userName, $privateKey] = $this->privateKeys[$hostIndex];

--- a/src/DockerManager.php
+++ b/src/DockerManager.php
@@ -629,7 +629,7 @@ final class DockerManager
         }
 
         $ssh = new SSH2($this->containerHosts[$hostIndex]);
-        for ($try = 1; $try <= self::MAX_CONNECT_RETRIES; ++$try) { // @todo: this stuff should probably be extracted into a method
+        for ($try = 1; $try <= self::MAX_CONNECT_RETRIES; ++$try) {
             $this->serviceContainer->logger->debug($callingMethod . '() retry loop', ['iteration' => $try]);
 
             try {


### PR DESCRIPTION
- Removes callbacks from exec() calls since they turned to be a bit unreliable in some scenarios
- Some general refactoring
- Update statistics to also generate a 7d and 30d dashboard